### PR TITLE
change covers dir to coverart

### DIFF
--- a/lib/lutris.py
+++ b/lib/lutris.py
@@ -158,7 +158,7 @@ def _get_art_paths(slug: str) -> Dict[str, Dict[str, str]]:
 
     icon_path = os.path.join(icons, f"lutris_{slug}.png")
     banner_path = os.path.join(lutris, 'banners', f"{slug}.jpg")
-    cover_path = os.path.join(lutris, 'covers', f"{slug}.jpg")
+    cover_path = os.path.join(lutris, 'coverart', f"{slug}.jpg")
 
     prefer_covers = _addon.getSettingBool('prefer_covers')
 


### PR DESCRIPTION
## Issue
Artwork when using the "use poster" setting did not load the images.

## Expected
Poster artwork should be loaded.

## Solution
I noticed the directory with "posters" is located in "coverart" instead of "covers"

![image](https://github.com/RobLoach/lutris-kodi-addon/assets/31508944/6d6a75cc-dec4-470c-8aa9-5cf2bf1cab84)
